### PR TITLE
Add tag support and analytics style guide

### DIFF
--- a/docs/remote_sensing/sentinel2_cloud_correction/sentinel_2_cloud_correction.md
+++ b/docs/remote_sensing/sentinel2_cloud_correction/sentinel_2_cloud_correction.md
@@ -1,7 +1,16 @@
-Creating Cloud Corrected Sentinel-2 Images 
-================
-Erick Verleye, ESIIL Software Developer  
-2023-08-08  
+---
+title: Creating Cloud Corrected Sentinel-2 Images
+authors:
+  - Erick Verleye
+date: 2023-08-08
+tags:
+  - remote-sensing
+  - sentinel-2
+  - cloud-correction
+---
+
+# Creating Cloud Corrected Sentinel-2 Images
+Erick Verleye, ESIIL Software Developer
 
 A common issue when working with remote imaging data is that for a single image,
 it is likely that the instrument's field of view is at least partially occulted by clouds.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,38 @@
+# Analytics Library Style Guide
+
+This document outlines conventions for adding new analyses to the library.
+
+## File naming
+- Place each analysis under an appropriate subdirectory in `docs/`.
+- Use short, descriptive, lowercase file names separated by hyphens (e.g. `my-analysis.md`).
+
+## Front matter
+Start every file with YAML front matter providing metadata used by the site:
+
+```yaml
+---
+title: Descriptive title
+authors:
+  - Your Name
+date: YYYY-MM-DD
+tags:
+  - topic
+  - method
+---
+```
+
+## Required sections
+Organize each entry with the following sections:
+
+1. **Description** – Explain the analysis, why it is valuable, the type of data it accepts, and suggest sources from the data library.
+2. **Usage Example** – Include a self-contained, copy‑and‑pasteable code snippet that loads a dataset from the data library, performs the analysis, and produces a plot demonstrating the results.
+3. **Interpretation and Heuristics** – Provide context for reading the results and guidance on common pitfalls or rules of thumb.
+
+## Writing tips
+- Use `#` for the document title and `##` for section headings.
+- Prefer concise sentences and active voice.
+- Include links to relevant data library entries and external resources when helpful.
+- Provide meaningful alt text for all images and plots.
+- Keep code blocks executable as written; import all required libraries in the snippet.
+
+Adhering to these guidelines ensures consistent, discoverable, and easy-to-understand analytics examples.

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,11 @@
+---
+title: Tags
+template: tags.html
+hide:
+  - navigation
+---
+
+# Tags
+
+A list of all tags used in the analytics library.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ nav:
   - Home: index.md
   - Remote Sensing:
       - How to Cloud Correct Sentinel-2 Images: remote_sensing/sentinel2_cloud_correction/sentinel_2_cloud_correction.md
+  - Tags: tags.md
+  - Style Guide: style-guide.md
 
 # Configuration
 theme:
@@ -35,6 +37,7 @@ theme:
     - toc.integrate
     - toc.follow
     - content.code.copy
+    - content.tags
   # Default values, taken from mkdocs_theme.yml
   language: en
   palette:
@@ -79,6 +82,7 @@ extra_css:
 
 plugins:
     - search
+    - tags
     - mkdocstrings
     - git-revision-date
     - mkdocs-jupyter:


### PR DESCRIPTION
## Summary
- enable Material tags plugin and navigation links
- document contribution standards for analysis entries
- tag Sentinel-2 example with metadata

## Testing
- `mkdocs build` *(fails: ModuleNotFoundError: No module named 'mkdocs.tests')*
- `pip install 'mkdocs-jupyter>=0.24.0'` *(fails: Could not find a version that satisfies the requirement due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68bf581b62f88325a019ce53a5326af5