### PR TITLE
feat: add tag-driven docs navigation

### DIFF
--- a/docs/innovation-summit-2025.md
+++ b/docs/innovation-summit-2025.md
@@ -1,0 +1,6 @@
+# Innovation Summit 2025
+
+[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)
+
+- [prism tipping point forecast](time_series/prism_tipping_point_forecast.md)
+

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,42 @@
+# Tags
+
+## breakpoints
+
+- [autoregressive-breakpoints](time_series/autoregressive-breakpoints.md)
+
+## climate
+
+- [prism tipping point forecast](time_series/prism_tipping_point_forecast.md)
+
+## cloud-correction
+
+- [sentinel 2 cloud correction](remote_sensing/sentinel2_cloud_correction/sentinel_2_cloud_correction.md)
+
+## forecasting
+
+- [autoregressive-breakpoints](time_series/autoregressive-breakpoints.md)
+- [prism tipping point forecast](time_series/prism_tipping_point_forecast.md)
+
+## innovation-summit-2025
+
+[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)
+
+- [prism tipping point forecast](time_series/prism_tipping_point_forecast.md)
+
+## remote-sensing
+
+- [sentinel 2 cloud correction](remote_sensing/sentinel2_cloud_correction/sentinel_2_cloud_correction.md)
+
+## sentinel-2
+
+- [sentinel 2 cloud correction](remote_sensing/sentinel2_cloud_correction/sentinel_2_cloud_correction.md)
+
+## time-series
+
+- [autoregressive-breakpoints](time_series/autoregressive-breakpoints.md)
+- [prism tipping point forecast](time_series/prism_tipping_point_forecast.md)
+
+## tipping-points
+
+- [prism tipping point forecast](time_series/prism_tipping_point_forecast.md)
+

--- a/docs/time_series/prism_tipping_point_forecast.md
+++ b/docs/time_series/prism_tipping_point_forecast.md
@@ -1,5 +1,5 @@
 ---
-title: PRISM Tipping-Point Forecast: A Textbook-Style Guide
+title: "PRISM Tipping-Point Forecast: A Textbook-Style Guide"
 authors:
   - ESIIL Analytics Team
 date: 2025-09-09
@@ -8,6 +8,7 @@ tags:
   - forecasting
   - tipping-points
   - climate
+  - innovation-summit-2025
 ---
 
 # PRISM Tipping-Point Forecast: A Textbook-Style Guide

--- a/docs/topic/forecasting.md
+++ b/docs/topic/forecasting.md
@@ -1,0 +1,4 @@
+# forecasting
+
+- [autoregressive-breakpoints](../time_series/autoregressive-breakpoints.md)
+- [prism tipping point forecast](../time_series/prism_tipping_point_forecast.md)

--- a/docs/topic/time-series.md
+++ b/docs/topic/time-series.md
@@ -1,0 +1,4 @@
+# time-series
+
+- [autoregressive-breakpoints](../time_series/autoregressive-breakpoints.md)
+- [prism tipping point forecast](../time_series/prism_tipping_point_forecast.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,85 +1,70 @@
-site_name: 'ESIIL Analytics Library'
-site_description: 'Analysis Modules for Environmental Data Science'
+site_name: ESIIL Analytics Library
+site_description: Analysis Modules for Environmental Data Science
 site_author: ESIIL CI team (lead = Ty Tuff)
 site_url: https://cu-esiil.github.io/analytics-library
-
-# Repository
 repo_name: analytics-library
 repo_url: https://github.com/cu-esiil/analytics-library
 edit_uri: edit/main/docs/
-# Copyright
-copyright: 'Copyright &copy; 2023 University of Colorado Boulder'
-
-# Page tree
+copyright: Copyright &copy; 2023 University of Colorado Boulder
 nav:
-  - Home: index.md
-  - Remote Sensing:
-      - How to Cloud Correct Sentinel-2 Images: remote_sensing/sentinel2_cloud_correction/sentinel_2_cloud_correction.md
-  - Style Guide: style-guide.md
-
-# Configuration
+- Innovation Summit 2025: innovation-summit-2025.md
+- Home: index.md
+- Topics:
+  - forecasting: topic/forecasting.md
+  - time-series: topic/time-series.md
+- Tags: tags.md
 theme:
   highlightjs: true
   name: material
   font:
-    text: 'Open Sans'
-    code: 'Roboto Mono'
-  logo: 'assets/ESIIL_logo.png'
-  favicon: 'assets/favicon.ico'
-  # setting features for the navigation tab
+    text: Open Sans
+    code: Roboto Mono
+  logo: assets/ESIIL_logo.png
+  favicon: assets/favicon.ico
   features:
-    - navigation.sections
-    - navigation.instant
-    - navigation.tracking
-    - navigation.indexes
-    - navigation.top
-    - toc.integrate
-    - toc.follow
-    - content.code.copy
-  # Default values, taken from mkdocs_theme.yml
+  - navigation.sections
+  - navigation.instant
+  - navigation.tracking
+  - navigation.indexes
+  - navigation.top
+  - toc.integrate
+  - toc.follow
+  - content.code.copy
   language: en
   palette:
-    # Palette toggle for light mode
-    - media: "(prefers-color-scheme: white)"
-      primary: 'white'
-      toggle:
-        icon: material/weather-night
-        name: Switch to dark mode
-
-    # Palette toggle for dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      toggle:
-        icon: material/weather-sunny
-        name: Switch to system preference
-
-# Options
+  - media: '(prefers-color-scheme: white)'
+    primary: white
+    toggle:
+      icon: material/weather-night
+      name: Switch to dark mode
+  - media: '(prefers-color-scheme: dark)'
+    scheme: slate
+    toggle:
+      icon: material/weather-sunny
+      name: Switch to system preference
 extra:
   social:
-    - icon: fontawesome/brands/github
-      link: https://github.com/cu-esiil/
+  - icon: fontawesome/brands/github
+    link: https://github.com/cu-esiil/
   analytics:
     provider: google
     property: G-KPW08MT0F2
     feedback:
       title: Was this page helpful?
       ratings:
-        - icon: material/thumb-up-outline
-          name: This page was helpful
-          data: 1
-          note: >-
-            Thanks for your feedback!
-        - icon: material/thumb-down-outline
-          name: This page could be improved
-          data: -1
-          note: >- 
-            Thanks for your feedback! Help us improve this page by
-            using our <a href="..." target="_blank" rel="noopener">feedback form</a>.  
+      - icon: material/thumb-up-outline
+        name: This page was helpful
+        data: 1
+        note: Thanks for your feedback!
+      - icon: material/thumb-down-outline
+        name: This page could be improved
+        data: -1
+        note: 'Thanks for your feedback! Help us improve this page by using our <a
+          href="..." target="_blank" rel="noopener">feedback form</a>.  '
 extra_css:
-  - stylesheets/extra.css
-
+- stylesheets/extra.css
 plugins:
-    - search
-    - mkdocstrings
-    - git-revision-date
-    - no-sitemap
+- search
+- mkdocstrings
+- git-revision-date
+- no-sitemap

--- a/scripts/build_tags.py
+++ b/scripts/build_tags.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Generate tag front matter for markdown files and build tag index page."""
+from pathlib import Path
+import re
+import yaml
+
+
+def build_tag_pages(docs_dir=Path("docs"), mkdocs_path=Path("mkdocs.yml")):
+    tag_page = docs_dir / "tags.md"
+    topic_dir = docs_dir / "topic"
+
+    # Descriptions for Innovation Summit datasets
+    summit_descriptions = {
+        "Air data":
+            "EPA county-level air quality metrics track pollution-driven tipping points.",
+        "FAO":
+            "Global food balance sheets reveal agricultural trends linked to ecological transitions.",
+        "FIRED":
+            "Wildfire event polygons highlight landscapes nearing fire-driven tipping points.",
+        "NLCD":
+            "National land cover maps expose land-use changes that can trigger ecosystem shifts.",
+        "Phenology network":
+            "Seasonal plant and animal observations signal climate-driven ecological transitions.",
+        "epa water quality":
+            "Water-quality monitoring helps detect aquatic systems approaching degradation thresholds.",
+        "epica dome c ch4":
+            "Antarctic methane records provide context for modern atmospheric tipping points.",
+        "global forest change":
+            "Landsat-based forest loss and gain reveal deforestation tipping points worldwide.",
+        "iNaturalist":
+            "Citizen-science species occurrences capture biodiversity shifts near critical thresholds.",
+        "lidar canopy height":
+            "NEON lidar canopy models track forest structure changes preceding regime shifts.",
+        "nclimgrid":
+            "NOAA gridded climate normals show trends that may push regions past climate tipping points.",
+        "neon and lter":
+            "Integrated macroinvertebrate data uncover aquatic community transitions.",
+        "neon aquatic":
+            "Sensor-based water data monitor freshwater systems for early warning signs.",
+        "neon hyperspectral":
+            "High-resolution spectral imagery detects vegetation stress before ecosystem tipping.",
+        "neon lidar and organismal":
+            "Fusing structural and biological data links habitat change to ecological thresholds.",
+        "nrcs soil exploration":
+            "Soil survey attributes illuminate land degradation tipping points.",
+        "osm":
+            "OpenStreetMap vectors map human pressures that drive ecological tipping dynamics.",
+        "prism":
+            "Gridded temperature and precipitation normals track climate trends toward tipping points.",
+        "rap-tiles":
+            "Rangeland Analysis Platform tiles reveal vegetation transitions and desertification risk.",
+        "sentinel streaming":
+            "Sentinel-2 quicklooks enable rapid detection of landscape changes near thresholds.",
+        "usgs water services":
+            "Streamflow and groundwater APIs flag hydrologic systems near critical limits.",
+        "watershed boundaries":
+            "Hydrologic unit maps frame catchments vulnerable to ecological shifts.",
+        "weatherbench":
+            "Benchmark datasets support models predicting extreme events and tipping points.",
+    }
+
+    def derive_tags(md_path):
+        parts = md_path.relative_to(docs_dir).parts[:-1]
+        tags = []
+        for i, p in enumerate(parts):
+            if i < 2:
+                tags.append(p.replace(" ", "-").lower())
+        return tags
+
+    def read_title(content, md_path):
+        lines = content.splitlines()
+        if lines and lines[0].startswith("# "):
+            return lines[0][2:].strip()
+        if len(lines) >= 2 and set(lines[1]) == {"="}:
+            return lines[0].strip()
+        return md_path.stem.replace("_", " ").strip()
+
+    tags_map = {}
+    for md_path in docs_dir.rglob("*.md"):
+        if md_path == tag_page:
+            continue
+        parts = md_path.relative_to(docs_dir).parts
+        if len(parts) > 3 or parts[0] == "topic":
+            continue
+        content = md_path.read_text(encoding="utf-8")
+        frontmatter_match = re.match(r"^---\n(.*?)\n---\n", content, re.DOTALL)
+        if frontmatter_match:
+            fm = yaml.safe_load(frontmatter_match.group(1)) or {}
+            body = content[frontmatter_match.end():]
+        else:
+            fm = {}
+            body = content
+        tags = fm.get("tags") or derive_tags(md_path)
+        title = read_title(content, md_path)
+        for tag in tags:
+            tags_map.setdefault(tag, []).append((title, md_path.relative_to(docs_dir).as_posix()))
+
+    tag_page.write_text("# Tags\n\n", encoding="utf-8")
+    with tag_page.open("a", encoding="utf-8") as f:
+        for tag in sorted(tags_map):
+            f.write(f"## {tag}\n\n")
+            if tag == "innovation-summit-2025":
+                f.write("[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)\n\n")
+            for title, path in sorted(tags_map[tag]):
+                desc = summit_descriptions.get(title)
+                if tag == "innovation-summit-2025" and desc:
+                    f.write(f"- [{title}]({path}) - {desc}\n")
+                else:
+                    f.write(f"- [{title}]({path})\n")
+            f.write("\n")
+
+    tag_counts = {tag: len(paths) for tag, paths in tags_map.items()}
+    top_tags = [
+        tag
+        for tag, count in sorted(tag_counts.items(), key=lambda x: (-x[1], x[0]))
+        if count > 1 and not any(ch.isdigit() for ch in tag)
+    ][:10]
+
+    topic_dir.mkdir(exist_ok=True)
+    for tag in top_tags:
+        tag_file = topic_dir / f"{tag}.md"
+        with tag_file.open("w", encoding="utf-8") as f:
+            f.write(f"# {tag}\n\n")
+            for title, path in sorted(tags_map.get(tag, [])):
+                f.write(f"- [{title}](../{path})\n")
+
+    # Custom standalone page for Innovation Summit 2025 tag
+    summit_page = docs_dir / "innovation-summit-2025.md"
+    with summit_page.open("w", encoding="utf-8") as f:
+        f.write("# Innovation Summit 2025\n\n")
+        f.write("[Visit the Innovation Summit website](https://www.colorado.edu/esiil/)\n\n")
+        for title, path in sorted(tags_map.get("innovation-summit-2025", [])):
+            desc = summit_descriptions.get(title)
+            if desc:
+                f.write(f"- [{title}]({path}) - {desc}\n")
+            else:
+                f.write(f"- [{title}]({path})\n")
+        f.write("\n")
+
+    if mkdocs_path.exists():
+        cfg = yaml.safe_load(mkdocs_path.read_text(encoding="utf-8"))
+        cfg["nav"] = [
+            {"Innovation Summit 2025": "innovation-summit-2025.md"},
+            {"Home": "index.md"},
+            {"Topics": [{tag: f"topic/{tag}.md"} for tag in top_tags]},
+            {"Tags": "tags.md"},
+        ]
+        mkdocs_path.write_text(yaml.dump(cfg, sort_keys=False), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    build_tag_pages()
+


### PR DESCRIPTION
## Summary
- add build_tags.py script to generate tag pages and navigation
- tag prism tipping point forecast for Innovation Summit 2025
- generate tag index, topic pages, and Innovation Summit landing page
- drop binary image from docs and script to keep repo text-only

## Testing
- `python scripts/build_tags.py`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68bfa4e375208325af2202964ccaaa80