### PR TITLE
Fix broken logo in documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,8 +19,8 @@ theme:
   font:
     text: Open Sans
     code: Roboto Mono
-  logo: assets/ESIIL_logo.png
-  favicon: assets/favicon.ico
+  logo: ESIIL_logo.png
+  favicon: favicon.ico
   features:
   - navigation.sections
   - navigation.instant


### PR DESCRIPTION
## Summary
- reference logo and favicon in mkdocs configuration using correct paths

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68bfb70cbd048325925dfe22f010738f