### PR TITLE
docs: add random forest NDVI image

### DIFF
--- a/docs/remote_sensing/post_fire_tipping_points_random_forest/index.md
+++ b/docs/remote_sensing/post_fire_tipping_points_random_forest/index.md
@@ -930,3 +930,5 @@ def produce_figures(
 # )
 # display(fig_facets)
 ```
+
+![Random Forest NDVI Fire](images/random_forest_nvdi_fire.png)


### PR DESCRIPTION
## Summary
- embed NDVI fire example image below code snippet in random forest tipping analysis docs

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68c04fdfea7083258f7abf37aad487b4