### PR TITLE
Move images to top of PRISM and Random Forest docs

### DIFF
--- a/docs/remote_sensing/post_fire_tipping_points_random_forest/index.md
+++ b/docs/remote_sensing/post_fire_tipping_points_random_forest/index.md
@@ -15,6 +15,8 @@ tags:
 
 # Burning Boundaries: Random Forest Early Warnings for Post-Fire Collapse
 
+![Random Forest NDVI Fire](images/random_forest_nvdi_fire.png)
+
 ## Introduction
 
 Wildfires can push ecosystems across **tipping points**—for example, from forests to shrublands—when vegetation fails to recover after disturbance. This analytics entry describes a reproducible workflow that:
@@ -931,4 +933,3 @@ def produce_figures(
 # display(fig_facets)
 ```
 
-![Random Forest NDVI Fire](images/random_forest_nvdi_fire.png)

--- a/docs/time_series/prism_tipping_point_forecast/index.md
+++ b/docs/time_series/prism_tipping_point_forecast/index.md
@@ -13,6 +13,8 @@ tags:
 
 # Finding Breaks and Forecasting Climate data using PRISM
 
+![PRISM forecast with detected breakpoint](images/forecast_and_breakpoint.png)
+
 ## Introduction
 Climate systems are often assumed to change gradually, but in many cases they exhibit **abrupt shifts** or **“tipping points”** where the rate of change accelerates or decelerates. Detecting and forecasting such breaks in climate time series is important for understanding regional climate impacts, anticipating ecosystem stress, and informing adaptation planning. This workflow combines data streaming, change-point detection, and time-series forecasting to provide a reproducible way of investigating potential tipping points in observed climate records.
 
@@ -507,7 +509,6 @@ def plot_prism_tipping_point_forecast(
 fig, info, series = plot_prism_tipping_point_forecast(place="Boulder, CO", start="1981-01", max_forecast_years=20)
 ```
 
-![PRISM forecast with detected breakpoint](images/forecast_and_breakpoint.png)
 
 ```r
 # PRISM tipping-point forecast in R (VSI + month backoff + scale/offset safe)


### PR DESCRIPTION
## Summary
- Display PRISM forecast plot immediately under the title in the PRISM tipping-point forecast guide.
- Show Random Forest NDVI fire visualization right after the title in the post-fire tipping-point analysis doc.

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c0541f96bc8325902a5074a2f44776