### PR TITLE
Add contribution guide placeholder and sidebar link

### DIFF
--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -1,0 +1,14 @@
+---
+title: How to Contribute
+authors:
+  - ESIIL Team
+date: 2025-09-12
+tags:
+  - project
+  - contributing
+---
+
+# How to Contribute
+
+This page is a placeholder for contribution guidelines. Detailed instructions on how to contribute to the Analytics Library will be added soon.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - forecasting: topic/forecasting.md
   - time-series: topic/time-series.md
 - Tags: tags.md
+- How to Contribute: how-to-contribute.md
 theme:
   highlightjs: true
   name: material


### PR DESCRIPTION
## Summary
- add placeholder "How to Contribute" page for future contribution guidelines
- link contribution guide from the site navigation

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c4515a8ec083258e0f6fb7ac1506d6