### PR TITLE
Link logo to main oasis page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ theme:
       icon: material/weather-sunny
       name: Switch to system preference
 extra:
+  homepage: https://cu-esiil.github.io/home/
   social:
   - icon: fontawesome/brands/github
     link: https://github.com/cu-esiil/


### PR DESCRIPTION
## Summary
- configure the Material theme homepage link so the header logo sends users to https://cu-esiil.github.io/home/

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68c86076805483259dd3d2e74eccb576