### PR TITLE
Update site logo to new image

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,7 @@ theme:
   font:
     text: Open Sans
     code: Roboto Mono
-  logo: ESIIL_logo.png
+  logo: https://raw.githubusercontent.com/CU-ESIIL/data-library/main/docs/assets/esiil_oasis_logo.png
   favicon: favicon.ico
   features:
   - navigation.sections


### PR DESCRIPTION
## Summary
- point the MkDocs theme logo to the new ESIIL Oasis logo hosted in the data-library repository

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68c99f9aae3483259f60f95104abf944